### PR TITLE
k8s advertised host fix

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && \
     tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
     rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
 
-ADD scripts/start-kafka.sh /usr/bin/start-kafka.sh
+COPY scripts/start-kafka.sh /usr/bin/start-kafka.sh
 
 # Supervisor config
-ADD supervisor/kafka.conf supervisor/zookeeper.conf /etc/supervisor/conf.d/
+COPY supervisor/kafka.conf supervisor/zookeeper.conf /etc/supervisor/conf.d/
 
 # 2181 is zookeeper, 9092 is kafka
 EXPOSE 2181 9092

--- a/kafka/dockerbuild.sh
+++ b/kafka/dockerbuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+COMMIT_HASH=$(git rev-parse --short HEAD)
+
+docker build -t leanix/docker-kafka:0.10.1.0-k8s-${COMMIT_HASH} .

--- a/kafka/dockerbuild.sh
+++ b/kafka/dockerbuild.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-COMMIT_HASH=$(git rev-parse --short HEAD)
-
-docker build -t leanix/docker-kafka:0.10.1.0-k8s-${COMMIT_HASH} .

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -16,8 +16,7 @@ fi
 
 # Mounted kubernetes configMap values are read only. Since we need to write to the server.properties file
 # we mount the data to /tmp and then copy it to the target folder to be modified. https://github.com/kubernetes/kubernetes/issues/62099
-echo "Copying /tmp/server.properties to ${KAFKA_HOME}/config/server.properties"
-cp /tmp/server.properties $KAFKA_HOME/config/server.properties
+cp -v /tmp/server.properties $KAFKA_HOME/config/server.properties
 
 
 # Set the external host and port

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -14,6 +14,10 @@ if [ ! -z "$HELIOS_PORT_kafka" ]; then
     ADVERTISED_PORT=`echo $HELIOS_PORT_kafka | cut -d':' -f 2`
 fi
 
+# Mounted kubernetes configMap values are read only. Since we need to write to the server.properties file
+# we mount the data to /tmp and then copy it to the target folder to be modified. https://github.com/kubernetes/kubernetes/issues/62099
+cp /tmp/server.properties $KAFKA_HOME/config/server.properties
+
 # Set the external host and port
 if [ ! -z "$ADVERTISED_HOST" ]; then
     echo "advertised host: $ADVERTISED_HOST"

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -16,7 +16,9 @@ fi
 
 # Mounted kubernetes configMap values are read only. Since we need to write to the server.properties file
 # we mount the data to /tmp and then copy it to the target folder to be modified. https://github.com/kubernetes/kubernetes/issues/62099
+echo "Copying /tmp/server.properties to ${KAFKA_HOME}/config/server.properties"
 cp /tmp/server.properties $KAFKA_HOME/config/server.properties
+
 
 # Set the external host and port
 if [ ! -z "$ADVERTISED_HOST" ]; then


### PR DESCRIPTION
This PR enables to overwrite the advertised host settings in the `server.properties` file of kafka via env vars